### PR TITLE
docs(process): standardiser tâche+branche et doc Copilotage

### DIFF
--- a/Copilotage/COPILOTAGE_WORKFLOW.md
+++ b/Copilotage/COPILOTAGE_WORKFLOW.md
@@ -1,0 +1,25 @@
+# Flux de travail standard pour agents IA
+
+Objectif: garantir que chaque travail suit une discipline traçable via GitHub.
+
+Règles obligatoires:
+- Chaque travail démarre par une tâche (issue) GitHub.
+- Une branche dédiée est créée: `<type>/issue-<num>-<slug>` (ex: `feat/issue-42-vision-agent`).
+- Tous les commits référencent l’issue: `... (#<num>)` ou `Refs #<num>`.
+- Une Pull Request relie la branche à `master/main` et ferme l’issue (`Closes #<num>`).
+- Quality gates dans la PR: build/lint/tests, checklist "Done".
+
+Pratiques recommandées:
+- Petites PRs, descriptions concises, changelog clair.
+- CI minimale dans sous-modules; lint (ruff/black) à venir.
+
+Automatisation:
+- Utiliser `Copilotage/scripts/devops/gh_task_init.sh` pour ouvrir une issue et créer la branche.
+
+Cheatsheet:
+- Issue types: feat | fix | docs | chore | refactor | perf | test | ci
+- Slug court, kebab-case.
+
+---
+
+Mainteneur: consigner tout écart dans l’issue.

--- a/Copilotage/scripts/README.md
+++ b/Copilotage/scripts/README.md
@@ -9,3 +9,6 @@ Installation rapide:
 
 Exécution tests:
 - pytest Copilotage/scripts/tests -q
+
+Automatisation tâches/branches:
+- devops/gh_task_init.sh — crée une issue et une branche associée

--- a/Copilotage/scripts/devops/gh_task_init.sh
+++ b/Copilotage/scripts/devops/gh_task_init.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh_task_init.sh — ouvre (ou réutilise) une issue et crée une branche dédiée
+# Usage: gh_task_init.sh "[feat] Implémenter X" docs|feat|fix|chore|ci|refactor|test "slug-kebab"
+
+TITLE=${1:-}
+TYPE=${2:-docs}
+SLUG=${3:-}
+
+if [[ -z "$TITLE" || -z "$SLUG" ]]; then
+  echo "Usage: $0 \"[feat] Mon titre\" <type> <slug>" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI requis" >&2
+  exit 3
+fi
+
+# Cherche une issue ouverte de même titre
+ISSUE_NUM=$(gh issue list --search "$TITLE" --state open --json number,title 2>/dev/null | jq -r '.[] | select(.title=="'$TITLE'") | .number' || true)
+if [[ -z "$ISSUE_NUM" ]]; then
+  ISSUE_URL=$(gh issue create --title "$TITLE" --body "Créée via gh_task_init.sh" || true)
+  ISSUE_NUM=${ISSUE_URL##*/}
+fi
+
+BRANCH="${TYPE}/issue-${ISSUE_NUM}-${SLUG}"
+if git show-ref --verify --quiet refs/heads/$BRANCH; then
+  git checkout $BRANCH
+else
+  git checkout -b $BRANCH
+fi
+
+git push -u origin HEAD || true
+
+echo "Issue #$ISSUE_NUM" >&2
+echo "Branche: $BRANCH" >&2


### PR DESCRIPTION
Implémente les règles: chaque travail doit avoir une issue + branche. Ajoute COPILOTAGE_WORKFLOW.md et le script devops/gh_task_init.sh. Closes #16.