### PR TITLE
docs(journal): règle et script de journalisation Copilotage (host+pid)

### DIFF
--- a/Copilotage/COPILOTAGE_WORKFLOW.md
+++ b/Copilotage/COPILOTAGE_WORKFLOW.md
@@ -16,6 +16,11 @@ Pratiques recommandées:
 Automatisation:
 - Utiliser `Copilotage/scripts/devops/gh_task_init.sh` pour ouvrir une issue et créer la branche.
 
+Journalisation Copilotage (obligatoire):
+- À chaque session, ajouter un fichier `Copilotage/journal/<date>-<host>-pid<pid>-<session>.md`.
+- Contenu minimal: Contexte, Décisions & actions clés, Liens (issues/PR), Tests/quality gates, Prochaines étapes.
+- Nommage: `YYYY-MM-DD-<host>-pid<pid>-<slug>.md` (host: ex. Hauru; pid: pid VSCode si dispo, sinon shell).
+
 Cheatsheet:
 - Issue types: feat | fix | docs | chore | refactor | perf | test | ci
 - Slug court, kebab-case.

--- a/Copilotage/journal/2025-08-30-hauru-pid74498-session.md
+++ b/Copilotage/journal/2025-08-30-hauru-pid74498-session.md
@@ -1,0 +1,19 @@
+# Journal de session — 2025-08-30 (hauru, pid 74498)
+
+Contexte: ...
+
+Décisions & actions clés:
+- ...
+
+Liens:
+- Issues/PR: ...
+
+Tests/quality gates:
+- ...
+
+Prochaines étapes:
+- ...
+
+---
+
+Agent: journal créé automatiquement.

--- a/Copilotage/journal/2025-08-30-hauru-pid74498-session.md
+++ b/Copilotage/journal/2025-08-30-hauru-pid74498-session.md
@@ -1,19 +1,28 @@
 # Journal de session — 2025-08-30 (hauru, pid 74498)
 
-Contexte: ...
+Contexte: mise en place et formalisation des règles de travail (issue+branche+PR), initialisation CI/licences dans les sous-modules, et instauration d’une journalisation systématique côté Copilotage.
 
 Décisions & actions clés:
-- ...
+- Règle process actée: chaque travail = issue GitHub + branche dédiée + PR (commits référencent l’issue, la PR la ferme via "Closes #<num>").
+- Ajout LICENSE MIT et d’un workflow CI minimal dans les 6 sous-modules; puis mise à jour des pointeurs de sous-modules dans le parent.
+- Ajout de la doc de workflow: `Copilotage/COPILOTAGE_WORKFLOW.md`.
+- Ajout des scripts d’automatisation: `Copilotage/scripts/devops/gh_task_init.sh` (issue+branche) et `Copilotage/scripts/devops/journal_session.sh` (journal).
+- Ouverture des PRs associées aux règles:
+	- PR process (fermera #16): #17
+	- PR journalisation (Refs #18): #19
 
 Liens:
-- Issues/PR: ...
+- Issue process: #16 — PR #17
+- Issue journalisation: #18 — PR #19
 
 Tests/quality gates:
-- ...
+- Pytest scripts: 5/5 PASS.
+- CI minimal présent dans chaque sous-module (sanity check GitHub Actions).
 
 Prochaines étapes:
-- ...
+- Étendre lint/format (ruff/black) et l’intégrer dans parent et sous-modules.
+- Définir règles de protection de branche et templates d’issue/PR.
 
 ---
 
-Agent: journal créé automatiquement.
+Agent: journal mis à jour automatiquement.

--- a/Copilotage/journal/2025-08-30-session.md
+++ b/Copilotage/journal/2025-08-30-session.md
@@ -1,0 +1,24 @@
+# Journal de session — 2025-08-30
+
+Contexte: mise en place des règles de travail (issue+branche), initialisation CI/licences des sous-modules, et journalisation Copilotage.
+
+Décisions & actions clés:
+- Règle process actée: chaque travail = issue GH + branche dédiée + PR (référence commits, Closes #<num>).
+- Ajout LICENSE MIT et CI minimal dans les 6 sous-modules; mise à jour des pointeurs.
+- Ajout doc de workflow: `Copilotage/COPILOTAGE_WORKFLOW.md` et script `devops/gh_task_init.sh`.
+- Ouverture PR #17 pour la règle process (fermera #16).
+- Lancement de la règle de journalisation (cette entrée), issue #18, branche `docs/issue-18-copilotage-journal`.
+
+Liens:
+- Issue process: #16 — PR #17
+- Issue journalisation: #18 — PR à ouvrir
+
+Tests/quality gates:
+- Pytest scripts: 5/5 PASS.
+
+Prochaines étapes:
+- Étendre lint/format (ruff/black) et intégrer aux sous-modules.
+
+---
+
+Agent: journal créé automatiquement.

--- a/Copilotage/scripts/README.md
+++ b/Copilotage/scripts/README.md
@@ -12,3 +12,6 @@ Exécution tests:
 
 Automatisation tâches/branches:
 - devops/gh_task_init.sh — crée une issue et une branche associée
+
+Journalisation:
+- devops/journal_session.sh — génère un squelette de journal dans Copilotage/journal

--- a/Copilotage/scripts/devops/journal_session.sh
+++ b/Copilotage/scripts/devops/journal_session.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# journal_session.sh — crée une entrée de journal Copilotage pour la date courante
+# Usage: journal_session.sh "slug-de-session"  # ex: journal_session.sh session
+
+SESSION=${1:-session}
+DATE=$(date +%F)
+HOST=$(hostname -s 2>/dev/null || hostname)
+# Utiliser le PID VS Code si dispo, sinon PID du shell
+PID=${VSCODE_PID:-$$}
+DIR="Copilotage/journal"
+FILE="$DIR/${DATE}-${HOST}-pid${PID}-${SESSION}.md"
+
+mkdir -p "$DIR"
+if [[ -f "$FILE" ]]; then
+  echo "Journal déjà existant: $FILE" >&2
+  exit 0
+fi
+
+cat > "$FILE" <<EOF
+# Journal de session — ${DATE} (${HOST}, pid ${PID})
+
+Contexte: ...
+
+Décisions & actions clés:
+- ...
+
+Liens:
+- Issues/PR: ...
+
+Tests/quality gates:
+- ...
+
+Prochaines étapes:
+- ...
+
+---
+
+Agent: journal créé automatiquement.
+EOF
+
+echo "$FILE"


### PR DESCRIPTION
Ajoute la règle de journalisation dans COPILOTAGE_WORKFLOW.md et le script devops/journal_session.sh. Génère le journal de cette session. Refs #18.