### PR TITLE
[journal:totoro-pid61069] docs: Copilotage: owner labels PR/Issues (docs + templates) (Refs #28)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
-Titre: [journal:<host>-pid<pid>] [model:<nom>] <type>: <résumé court> (Refs #<issue>)
+Titre: [journal:<host>-pid<pid>] [model:<nom>] [owner:human|agent] <type>: <résumé court> (Refs #<issue>)
 
 Contexte
 - Issue liée: #<num>
 - Branche: <type>/issue-<num>-<slug>
 - Agent/Session: [journal:<host>-pid<pid>] (ou [agent:<id>] si PID indisponible)
 - Modèle (optionnel): [model:<nom>] (ex: gpt-4o, claude-3.5)
+- Propriétaire (optionnel): [owner:human] pour marquer une PR portée par un humain (sinon propriétaire inféré)
 
 Changements
 - [ ] …
@@ -13,10 +14,10 @@ Vérifications
 - [ ] CI passe (CodeQL, CI minimal)
 - [ ] Docs/dashboard impactés mis à jour si nécessaire
 - [ ] Journal de session ajouté dans `Copilotage/journal/`
-- [ ] Labels auto présents: `agent:<id>`, `journal:<host>-pid<pid>` et si applicable `model:<nom>`
+- [ ] Labels auto présents: `agent:<id>`, `journal:<host>-pid<pid>`, `owner:human|agent` et si applicable `model:<nom>`
 - [ ] Merge par un agent différent (cross-check)
 
 Clôture
 - Closes #<num> (remplacer si pertinent)
 
-Astuce: utilisez `Copilotage/scripts/devops/gh_pr_open.sh` pour générer le titre conforme.
+Astuce: utilisez `Copilotage/scripts/devops/gh_pr_open.sh` pour générer le titre conforme (`--model`, `--owner`).

--- a/Copilotage/AGENT_CONVENTION.md
+++ b/Copilotage/AGENT_CONVENTION.md
@@ -5,6 +5,7 @@ Objectif: distinguer les PRs par agent pour permettre des validations croisées.
 ## Comment marquer une PR
 - Ajoutez dans le titre: `[journal:HOST-pidPID]` (ex: `[journal:totoro-pid12345]`).
 - Optionnel: ajoutez `[model:NOM]` (ex: `[model:gpt-4o]`, `[model:claude-3.5]`).
+- Optionnel: pour lever toute ambiguïté d’attribution, ajoutez `[owner:human]` si la PR est portée par un humain (sinon propriétaire inféré côté automatisation quand `journal`/`model` présents).
 - À défaut, utilisez un nom de branche: `agents/HOST/ma-feature` (moins précis; ne remplace pas le PID).
 
 ## Automatisation

--- a/Copilotage/COPILOTAGE_WORKFLOW.md
+++ b/Copilotage/COPILOTAGE_WORKFLOW.md
@@ -7,7 +7,7 @@ Règles obligatoires:
 - Une branche dédiée est créée: `<type>/issue-<num>-<slug>` (ex: `feat/issue-42-vision-agent`).
 - Tous les commits référencent l’issue: `... (#<num>)` ou `Refs #<num>`.
 - Une Pull Request relie la branche à `master/main` et ferme l’issue (`Closes #<num>`).
-- Titre de PR: inclure `[journal:HOST-pidPID]` (ex: `[journal:totoro-pid17771]`).
+- Titre de PR: inclure `[journal:HOST-pidPID]` (ex: `[journal:totoro-pid17771]`). Optionnels: `[model:NOM]`, `[owner:human|agent]`.
 - Quality gates dans la PR: build/lint/tests, checklist "Done".
 
 Pratiques recommandées:
@@ -16,7 +16,7 @@ Pratiques recommandées:
 
 Automatisation:
 - Utiliser `Copilotage/scripts/devops/gh_task_init.sh` pour ouvrir une issue et créer la branche.
-- Utiliser `Copilotage/scripts/devops/gh_pr_open.sh` pour ouvrir une PR avec préfixe automatique `[journal:HOST-pidPID]`.
+- Utiliser `Copilotage/scripts/devops/gh_pr_open.sh` pour ouvrir une PR avec préfixe automatique `[journal:HOST-pidPID]` (options `--model`, `--owner`).
 
 Journalisation Copilotage (obligatoire):
 - À chaque session, ajouter un fichier `Copilotage/journal/<date>-<host>-pid<pid>-<session>.md`.


### PR DESCRIPTION
PR ouverte via gh_pr_open.sh.\n\n- Branche: docs/issue-28-owner-labeling\n- Agent/Session: [journal:totoro-pid61069]\n- Modèle: n/a\n\nCloses #28